### PR TITLE
Support `.git`-less remotes

### DIFF
--- a/src/watchgha/watch_runs.py
+++ b/src/watchgha/watch_runs.py
@@ -78,7 +78,7 @@ def summary_style_icon(data):
 def main():
     repo_url, branch_name = sys.argv[1:]
     # repo_url = "https://github.com/nedbat/coveragepy.git"
-    m = re.fullmatch(r"https://github.com/([^/]+/[^/]+)\.git", repo_url)
+    m = re.fullmatch(r"https://github.com/([^/]+/[^/]+)(\.git|/)?", repo_url)
     url = f"https://api.github.com/repos/{m[1]}/actions/runs?per_page=40&branch={branch_name}"
 
     output = ""


### PR DESCRIPTION
I tend to have remotes without `.git`:


```console
$ git remote -v
origin	https://github.com/hugovk/tinytext (fetch)
origin	https://github.com/hugovk/tinytext (push)
$ git runs
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.11/bin/watch_gha_runs", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/watchgha/watch_runs.py", line 82, in main
    url = f"https://api.github.com/repos/{m[1]}/actions/runs?per_page=40&branch={branch_name}"
                                          ~^^^
TypeError: 'NoneType' object is not subscriptable
```

And sometimes with a trailing `/`:

```console
$ git remote -v
origin	https://github.com/hugovk/norwegianblue/ (fetch)
origin	https://github.com/hugovk/norwegianblue/ (push)
$ git runs
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.11/bin/watch_gha_runs", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/watchgha/watch_runs.py", line 82, in main
    url = f"https://api.github.com/repos/{m[1]}/actions/runs?per_page=40&branch={branch_name}"
                                          ~^^^
TypeError: 'NoneType' object is not subscriptable
```
