### PR TITLE
If GITHUB_TOKEN isn't set, tell httpx to try .netrc for auth.

### DIFF
--- a/src/watchgha/http_help.py
+++ b/src/watchgha/http_help.py
@@ -36,9 +36,12 @@ class Http:
         token = os.environ.get("GITHUB_TOKEN", "")
         if token:
             self.headers["Authorization"] = f"Bearer {token}"
+            self.auth = None
+        else:
+            self.auth = httpx.NetRCAuth()
 
     async def get_data(self, url):
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(auth=self.auth) as client:
             resp = None
             try:
                 for ntry in range(3):


### PR DESCRIPTION
Hi!  As far as I could tell, the current behaviour doesn't match the documentation - I could not get `watch_gha` to use my `~/.netrc` file (using [this](https://gist.github.com/sahilsk/ce21c39a6c2dbc2cd984#file-netrc) format).  This tiny yet ugly patch seems to fix it, making `httpx` use the `GITHUB_TOKEN` env var if set, and if not, trying netrc auth.

Unfortunately it will spew an error at the user if they have a ~/.netrc file with loose permissions, which they may not know or care about, but adding a configurable opt-in to having it try netrc seemed a bit much for a drive by, but let me know if I can do that instead.