### PR TITLE
Allow URL and API URL to be set via envvars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,10 @@ Now ``git runs`` will show a live display of the current runs on your branch.
 You can authenticate against GitHub if needed using either an entry in your
 .netrc file, or by setting the ``GITHUB_TOKEN`` environment variable.
 
+If you use GitHub Enterprise, you can set the environment variables
+``GITHUB_SERVER_URL`` (default: ``https://github.com``) and
+``GITHUB_API_URL`` (default: ``https://api.github.com``)
+to match your instance.
 
 Usage
 =====

--- a/src/watchgha/watch_runs.py
+++ b/src/watchgha/watch_runs.py
@@ -130,14 +130,15 @@ def gha_urls(repo, branch, sha):
     for repo_url in repo_urls:
         # repo_url = "https://github.com/owner/repo.git"
         # repo_url = "git@github.com:someorg/somerepo.git"
+        # see also https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
         repo_match = re.fullmatch(
-            r"(?:https://github.com/|git@github.com:)([^/]+/[^/]+?)(?:\.git|/)?",
+            rf"(?:{os.getenv('GITHUB_SERVER_URL', 'https://github.com')}/|git@github.com:)([^/]+/[^/]+?)(?:\.git|/)?",
             repo_url,
         )
         if repo_match is None:
             continue
 
-        url = f"https://api.github.com/repos/{repo_match[1]}/actions/runs?{url_args}"
+        url = f"{os.getenv('GITHUB_API_URL', 'https://api.github.com')}/repos/{repo_match[1]}/actions/runs?{url_args}"
         github_urls.append(url)
 
     if not github_urls:


### PR DESCRIPTION
This is useful for GitHub Enterprise (Server) instances.
Documentation about these variables is at https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables